### PR TITLE
Improve performance and add caching

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -9,6 +9,8 @@ import { AppComponent } from './app.component';
 import { SpinnerComponent } from './shared/spinner/spinner.component';
 import { ContentAnimateDirective } from './shared/directives/content-animate.directive';
 import { SharedModule } from './shared/shared.module';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { CacheInterceptor } from './cache.interceptor';
 
 
 @NgModule({
@@ -29,7 +31,9 @@ import { SharedModule } from './shared/shared.module';
     }),
   ],
   providers: [
-    { provide: Window, useValue: window },CustomPreloadingStrategy
+    { provide: Window, useValue: window },
+    CustomPreloadingStrategy,
+    { provide: HTTP_INTERCEPTORS, useClass: CacheInterceptor, multi: true }
   ],
   bootstrap: [AppComponent]
 })

--- a/src/app/cache.interceptor.ts
+++ b/src/app/cache.interceptor.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpInterceptor, HttpHandler, HttpRequest, HttpResponse } from '@angular/common/http';
+import { Observable, of } from 'rxjs';
+import { tap, shareReplay } from 'rxjs/operators';
+
+@Injectable()
+export class CacheInterceptor implements HttpInterceptor {
+  private cache = new Map<string, HttpResponse<any>>();
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    if (req.method !== 'GET') {
+      return next.handle(req);
+    }
+    const cached = this.cache.get(req.urlWithParams);
+    if (cached) {
+      return of(cached.clone());
+    }
+    return next.handle(req).pipe(
+      tap(event => {
+        if (event instanceof HttpResponse) {
+          this.cache.set(req.urlWithParams, event.clone());
+        }
+      }),
+      shareReplay(1)
+    );
+  }
+}

--- a/src/app/fn-o/fn-o.component.ts
+++ b/src/app/fn-o/fn-o.component.ts
@@ -1,11 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'app-fn-o',
   standalone: true,
   imports: [],
   templateUrl: './fn-o.component.html',
-  styleUrl: './fn-o.component.scss'
+  styleUrl: './fn-o.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FnOComponent {
 

--- a/src/app/icons/mdi/mdi.component.ts
+++ b/src/app/icons/mdi/mdi.component.ts
@@ -1,9 +1,10 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 
 @Component({
   selector: 'app-mdi',
   templateUrl: './mdi.component.html',
-  styleUrls: ['./mdi.component.scss']
+  styleUrls: ['./mdi.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class MdiComponent implements OnInit {
 

--- a/src/app/share/share.component.html
+++ b/src/app/share/share.component.html
@@ -795,7 +795,7 @@
                         >
                           <p-card>
                             <p-header>
-                              <img src="{{ news.text3 }}" />
+                              <img src="{{ news.text3 }}" loading="lazy" decoding="async" />
                             </p-header>
                             <h4>{{ news.text1 }}</h4>
                             <h5>{{ news.text2 }}</h5>

--- a/src/app/shared/navbar/navbar.component.html
+++ b/src/app/shared/navbar/navbar.component.html
@@ -88,7 +88,7 @@
       <div class="card-wrappertopcards">
         <div class="card bg-gradient-primary card-img-holder text-white" (click)="navigatenifty()">
           <div class="card-body">
-            <img src="assets/images/dashboard/circle.svg" class="card-img-absolute" alt="circle-image" />
+            <img src="assets/images/dashboard/circle.svg" class="card-img-absolute" alt="circle-image" loading="lazy" decoding="async" />
             <div
               style="text-transform: uppercase; font-weight: bold"
               [ngClass]="{
@@ -113,7 +113,7 @@
       <div class="card-wrappertopcards">
         <div class="card bg-gradient-primary card-img-holder text-white" (click)="navigatebanknifty()">
           <div class="card-body">
-            <img src="assets/images/dashboard/circle.svg" class="card-img-absolute" alt="circle-image" />
+            <img src="assets/images/dashboard/circle.svg" class="card-img-absolute" alt="circle-image" loading="lazy" decoding="async" />
             <div
               style="text-transform: uppercase; font-weight: bold"
               [ngClass]="{
@@ -137,7 +137,7 @@
       <div class="card-wrappertopcards">
         <div class="card bg-gradient-primary card-img-holder text-white" (click)="navigatepnifty()">
           <div class="card-body">
-            <img src="assets/images/dashboard/circle.svg" class="card-img-absolute" alt="circle-image" />
+            <img src="assets/images/dashboard/circle.svg" class="card-img-absolute" alt="circle-image" loading="lazy" decoding="async" />
             <div
               style="text-transform: uppercase; font-weight: bold"
               [ngClass]="{
@@ -181,6 +181,7 @@
               src="assets/images/dashboard/circle.svg"
               class="card-img-absolute"
               alt="circle-image"
+              loading="lazy" decoding="async"
             />
             <div
               style="text-transform: uppercase; font-weight: bold"
@@ -216,6 +217,7 @@
               src="assets/images/dashboard/circle.svg"
               class="card-img-absolute"
               alt="circle-image"
+              loading="lazy" decoding="async"
             />
             <div
               style="text-transform: uppercase; font-weight: bold"
@@ -250,6 +252,7 @@
               src="assets/images/dashboard/circle.svg"
               class="card-img-absolute"
               alt="circle-image"
+              loading="lazy" decoding="async"
             />
             <div
               style="text-transform: uppercase; font-weight: bold"
@@ -325,7 +328,7 @@
         styleClass="p-card-shadow"
       >
         <ng-template pTemplate="header">
-          <img alt="Card" src="{{ news.text3 }}" />
+          <img alt="Card" src="{{ news.text3 }}" loading="lazy" decoding="async" />
         </ng-template>
         <p>{{ news.text5 }}</p>
         <a href="{{ news.text2 }}" target="_blank" rel="noopener noreferer">{{

--- a/src/app/splash-screen/splash-screen.component.html
+++ b/src/app/splash-screen/splash-screen.component.html
@@ -1,4 +1,4 @@
 <div class="splash-screen">
-    <img src="../../assets/images/stockinsights.gif" alt="Splash GIF" />
+    <img src="../../assets/images/stockinsights.gif" alt="Splash GIF" loading="lazy" decoding="async" />
   </div>
   

--- a/src/app/splash-screen/splash-screen.component.ts
+++ b/src/app/splash-screen/splash-screen.component.ts
@@ -1,10 +1,11 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { Router } from '@angular/router';
 
 @Component({
   selector: 'app-splash-screen',
   templateUrl: './splash-screen.component.html',
-  styleUrls: ['./splash-screen.component.scss']
+  styleUrls: ['./splash-screen.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class SplashScreenComponent implements OnInit {
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -9,7 +9,7 @@
 // @import "./assets/scss/functions";
 // @import '~bootstrap/dist/css/bootstrap.css';
 // @import "~@mdi/font/scss/materialdesignicons";
-//  @import "~@angular/material/prebuilt-themes/indigo-pink.css";
+@import "~@angular/material/prebuilt-themes/indigo-pink.css";
 
 // /* === Template mixins === */
 // @import "./assets/scss/mixins/animation";


### PR DESCRIPTION
## Summary
- use Angular's OnPush change detection for small components
- lazy load images for faster rendering
- include Angular Material theme
- introduce simple HTTP cache interceptor
- register the interceptor and clean up providers

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888cec96df8832cb27fd50d8e1aa289